### PR TITLE
docs(readme): correct config example by moving author to params.author

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,11 @@ Add the theme to your `hugo.toml`:
 theme = "loficode"
 
 [params]
-  author = "Your Name"
   description = "Your site description"
+
+  [params.author]
+    name = "Your Name"
+    image = "images/profile.png"
 
   # Profile section
   [params.profile]


### PR DESCRIPTION
> TL;DR: The README uses author = "string", but the theme expects [params.author] as a table. This causes Hugo builds to fail. This MR corrects the README to match exampleSite and the template structure.

Using the example as-is caused Hugo to fail during build, since author needs to be nested under params.

The current example config in the readme caused my Hugo (`hugo v0.152.2+extended+withdeploy darwin/arm64 BuildDate=2025-10-24T15:31:49Z VendorInfo=brew` - it is unlikely to be version specific as it is not unexpected behaviour on hugo's behalf) to fail the build.

## Config I used

The config I used (copied from the Readme):
```toml
title = 'Portfolio'
theme = "loficode"

[params]
  author = "Rye"
  description = "Portfolio"

  # Profile section
  [params.profile]
    name = "Rye"
    tagline = "Your tagline here"
    photo = "images/avatar.png"

  # Social links - Supported platforms: github, twitter, linkedin, email, mastodon, youtube, instagram, facebook
  [params.social]
    github = "raisingpixels"
    twitter = "raisingpixels"
    # linkedin = "your-linkedin-username"
    # email = "your-email@example.com"
    # mastodon = "https://mastodon.social/@yourusername"
    # youtube = "https://youtube.com/@yourusername"
    # instagram = "your-instagram-username"
    # facebook = "your-facebook-username"

# Navigation menu
[[menu.main]]
  name = "About"
  url = "/about/"
  weight = 10

[[menu.main]]
  name = "Contact"
  url = "/contact/"
  weight = 20
```

## Resulting Error

This caused Hugo to fail build with: `Error: error building site: render: failed to render pages: render of "/" failed: "/fakepath/portfolio/themes/loficode/layouts/index.html:6:21": execute of template failed: template: index.html:6:21: executing "main" at <.Site.Params.Author.image>: can't evaluate field image in type string`

## Reason of the failure

In [`layouts/index.html` line 6](https://github.com/raisingpixels/loficode-hugo-theme/blob/dc4117fdcf84755ae002d00cccb791a9e3ede183/layouts/index.html#L6) it says:

```html
      <img
        src="{{ .Site.Params.Author.image | absURL }}"
        alt="{{ .Site.Params.Author.name }}"
        class="profile-photo"
      />
```

So `Site.Params.Author` can't be a string (like in the current example config), but must either be nested or the template must be changed, I think changing the example is easier.

## Suggested Fix

So I would suggest adjusting the config example in the Readme to the config of the [example site](https://github.com/raisingpixels/loficode-hugo-theme/blob/main/exampleSite/hugo.toml)

In the config of the example site:

```toml
[params]
  description = "A cozy example site showcasing the LofiCode Hugo theme"
  tagline = "Coding with coffee and lo-fi beats ☕🎵"

  # Profile section
  [params.author]
    name = "LofiCode Dev"
    image = "images/profile.png"
```

## Validation of suggested fix

The build was successful once i changed the config.

```toml
[params]
  description = "Portfolio"
  [params.author]
    name = "Rye"
    image = "images/avatar.png"
```

## diff of suggested change

Therefore my suggested change:

```diff
diff --git a/README.md b/README.md
index c2e366e..b41f993 100644
--- a/README.md
+++ b/README.md
@@ -47,9 +47,12 @@ Add the theme to your `hugo.toml`:
 theme = "loficode"
 
 [params]
-  author = "Your Name"
   description = "Your site description"
 
+  [params.author]
+    name = "Your Name"
+    image = "images/profile.png"
+
   # Profile section
   [params.profile]
     name = "Your Name"
```